### PR TITLE
improve mobile layout of team page

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -336,14 +336,14 @@ ul:not(.navbar-nav) > li {
 
 #listing-team {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(24vw, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 1vw;
     justify-content: center;
     align-items: center;
     justify-items: center;
 
     .card {
-        max-width: 25vw;
+        height: 100%;
     }
 
     .team-image {


### PR DESCRIPTION
Resolves #31. Progress towards #29: will now look like this:

<img width="545" height="925" alt="image" src="https://github.com/user-attachments/assets/62f35ed3-2b40-445e-90bc-49e29ed1af58" />

Instead of what it currently looks like:

<img width="545" height="925" alt="image" src="https://github.com/user-attachments/assets/20795430-ae73-4d8f-ba0a-2751fe47021d" />
